### PR TITLE
Fix tsconfig include paths

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,8 +26,8 @@
   },
   "include": [
     "next-env.d.ts",
-    "app/**/*",
-    "lib/**/*",
+    "src/app/**/*",
+    "src/lib/**/*",
     "scripts/**/*",
     "**/*.ts",
     "**/*.tsx"


### PR DESCRIPTION
## Summary
- point tsconfig includes to `src/app` and `src/lib`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next' or its corresponding type declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684f697c225483209e7d2364f947dffe